### PR TITLE
Version 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2022/07/20
+### Added
+- Add `DdsConversionOptions` to make mipmaps and shuffling configurable.
+### Fixed
+- DDS conversions from an image with width or height of 4 pixels will no longer cause an error.
+- Add `Bitmap` interface to documentation index.
+
 ## [0.2.0] - 2022/06/21
 ### Changed
 - Add options to DdsImage's `toShuffled()` and `toUnshuffled()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2022/07/20
 ### Added
 - Add `DdsConversionOptions` to make mipmaps and shuffling configurable.
+### Changed
+- Minimum image width and height are now 8 pixels.
 ### Fixed
-- DDS conversions from an image with width or height of 4 pixels will no longer cause an error.
 - Add `Bitmap` interface to documentation index.
 
 ## [0.2.0] - 2022/06/21

--- a/docs/index.json
+++ b/docs/index.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/sims4toolkit/misc/main/json-schemas/docs-index-schema.json",
   "versions": [
+    "0.2.1",
     "0.2.0",
     "0.1.0"
   ],
@@ -18,6 +19,8 @@
     {
       "name": "types",
       "items": [
+        "Bitmap",
+        "DdsConversionOptions",
         "DdsHeader",
         "PixelFormat"
       ]

--- a/docs/types/DdsConversionOptions.json
+++ b/docs/types/DdsConversionOptions.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://raw.githubusercontent.com/sims4toolkit/misc/main/json-schemas/docs-item-schema.json",
+  "header": {
+    "title": {
+      "prefix": "interface",
+      "name": "DdsConversionOptions"
+    },
+    "description": "Optional arguments to provide when creating a DDS image from another format.",
+    "sourceCode": "src/lib/options.ts"
+  },
+  "sections": [
+    {
+      "title": "Properties",
+      "content": [
+        {
+          "displayType": "property",
+          "name": "maxMipMaps",
+          "optional": true,
+          "description": "The maximum number of mipmaps to generate for a DDS image. This must be an integer between 1 and 15. If not provided, it is 15 by default.\n\nThis value includes the largest, highest-quality version of the image. To avoid scaling down the image at all, use a value of 1.",
+          "type": {
+            "name": "number"
+          }
+        },
+        {
+          "displayType": "property",
+          "name": "shuffle",
+          "optional": true,
+          "description": "Whether or not the resulting DDS image should be shuffled. If true, the DDS image will use DST5 compression. If false, it will use DXT5 compression. If not provided, it is false by default.",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s4tk/images",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@s4tk/images",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@jimp/core": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s4tk/images",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Models and algorithms for processing image resources.",
   "repository": {
     "type": "git",

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -1,0 +1,20 @@
+/**
+ * Optional arguments to provide when creating a DDS image from another format.
+ */
+export type DdsConversionOptions = Partial<{
+  /**
+   * The maximum number of mipmaps to generate for a DDS image. This must be an
+   * integer between 1 and 15. If not provided, it is 15 by default.
+   * 
+   * This value includes the largest, highest-quality version of the image. To
+   * avoid scaling down the image at all, use a value of 1.
+   */
+  maxMipMaps: number;
+
+  /**
+   * Whether or not the resulting DDS image should be shuffled. If true, the DDS
+   * image will use DST5 compression. If false, it will use DXT5 compression.
+   * If not provided, it is false by default.
+   */
+  shuffle: boolean;
+}>;


### PR DESCRIPTION
## [0.2.1] - 2022/07/20
### Added
- Add `DdsConversionOptions` to make mipmaps and shuffling configurable.
### Fixed
- DDS conversions from an image with width or height of 4 pixels will no longer cause an error.
- Add `Bitmap` interface to documentation index.